### PR TITLE
Bugfix - Perbaikan data lokal yang tidak sync ke server

### DIFF
--- a/lib/core/util/dio_logging_interceptor_refresh_token.dart
+++ b/lib/core/util/dio_logging_interceptor_refresh_token.dart
@@ -55,7 +55,7 @@ class DioLoggingInterceptorRefreshToken extends InterceptorsWrapper {
       );
     }
 
-    if (responseCode == 401 || responseCode == null) {
+    if (responseCode == 401) {
       final strRefreshToken = sharedPreferencesManager.getString(SharedPreferencesManager.keyRefreshToken) ?? '';
       if (strRefreshToken.isEmpty) {
         return handler.next(err);

--- a/lib/feature/database/dao/track/track_dao.dart
+++ b/lib/feature/database/dao/track/track_dao.dart
@@ -7,7 +7,7 @@ abstract class TrackDao {
   Future<List<Track>> findAllTrack(String userId);
 
   @insert
-  Future<void> insertTrack(Track track);
+  Future<int> insertTrack(Track track);
 
   @Query('DELETE FROM track WHERE id = :id')
   Future<void> deleteTrackById(int id);

--- a/lib/feature/presentation/bloc/tracking/tracking_bloc.dart
+++ b/lib/feature/presentation/bloc/tracking/tracking_bloc.dart
@@ -42,7 +42,12 @@ class TrackingBloc extends Bloc<TrackingEvent, TrackingState> {
     final response = result.response;
     final failure = result.failure;
     if (response != null) {
-      emit(SuccessCreateTimeTrackingState(files: event.body.files));
+      emit(
+        SuccessCreateTimeTrackingState(
+          files: event.body.files,
+          trackEntityId: event.trackEntityId,
+        ),
+      );
       return;
     }
 

--- a/lib/feature/presentation/bloc/tracking/tracking_event.dart
+++ b/lib/feature/presentation/bloc/tracking/tracking_event.dart
@@ -6,12 +6,16 @@ abstract class TrackingEvent {
 
 class CreateTimeTrackingEvent extends TrackingEvent {
   final CreateTrackBody body;
+  final int trackEntityId;
 
-  CreateTimeTrackingEvent({required this.body});
+  CreateTimeTrackingEvent({
+    required this.body,
+    required this.trackEntityId,
+  });
 
   @override
   String toString() {
-    return 'CreateTimeTrackingEvent{body: $body}';
+    return 'CreateTimeTrackingEvent{body: $body, trackEntityId: $trackEntityId}';
   }
 }
 

--- a/lib/feature/presentation/bloc/tracking/tracking_state.dart
+++ b/lib/feature/presentation/bloc/tracking/tracking_state.dart
@@ -21,14 +21,16 @@ class FailureTrackingState extends TrackingState {
 
 class SuccessCreateTimeTrackingState extends TrackingState {
   final List<String> files;
+  final int trackEntityId;
 
   SuccessCreateTimeTrackingState({
     required this.files,
+    required this.trackEntityId,
   });
 
   @override
   String toString() {
-    return 'SuccessCreateTimeTrackingState{files: $files}';
+    return 'SuccessCreateTimeTrackingState{files: $files, trackEntityId: $trackEntityId}';
   }
 }
 

--- a/lib/feature/presentation/page/home/home_page.dart
+++ b/lib/feature/presentation/page/home/home_page.dart
@@ -77,7 +77,6 @@ class _HomePageState extends State<HomePage> with TrayListener, WindowListener {
   var counterActivity = 0;
   DateTime? startTime;
   DateTime? finishTime;
-  Track? trackEntity;
   DateTime? infoDateTime;
 
   @override
@@ -329,9 +328,7 @@ class _HomePageState extends State<HomePage> with TrayListener, WindowListener {
             BlocListener<TrackingBloc, TrackingState>(
               listener: (context, state) {
                 if (state is FailureTrackingState) {
-                  if (trackEntity != null) {
-                    trackDao.insertTrack(trackEntity!);
-                  }
+                  /* Nothing to do in here */
                 } else if (state is SuccessCreateTimeTrackingState) {
                   final files = state.files;
                   for (final path in files) {
@@ -340,6 +337,8 @@ class _HomePageState extends State<HomePage> with TrayListener, WindowListener {
                       file.deleteSync();
                     }
                   }
+                  final trackEntityId = state.trackEntityId;
+                  trackDao.deleteTrackById(trackEntityId);
                 } else if (state is SuccessCronTrackingState) {
                   // TODO: tampilkan info last sync at: 22:09 04 Jul 2023
                   // TODO: info ini akan ditampilkan dibagian paling bawah sama seperti tampilan hubstaff
@@ -973,7 +972,7 @@ class _HomePageState extends State<HomePage> with TrayListener, WindowListener {
 
     final activity = percentActivity.round();
 
-    trackEntity = Track(
+    final trackEntity = Track(
       userId: userId,
       taskId: taskId!,
       startDate: formattedStartDateTime,
@@ -984,6 +983,7 @@ class _HomePageState extends State<HomePage> with TrayListener, WindowListener {
       projectName: selectedProject?.name ?? '',
       taskName: selectedTask?.name ?? '',
     );
+    final trackEntityId = await trackDao.insertTrack(trackEntity);
 
     trackingBloc.add(
       CreateTimeTrackingEvent(
@@ -996,6 +996,7 @@ class _HomePageState extends State<HomePage> with TrayListener, WindowListener {
           duration: durationInSeconds,
           files: files.split(','),
         ),
+        trackEntityId: trackEntityId,
       ),
     );
   }

--- a/test/feature/presentation/bloc/tracking/tracking_bloc_test.dart
+++ b/test/feature/presentation/bloc/tracking/tracking_bloc_test.dart
@@ -56,7 +56,7 @@ void main() {
       ),
     );
     final tParams = ParamsCreateTrack(body: tBody);
-    final tEvent = CreateTimeTrackingEvent(body: tBody);
+    final tEvent = CreateTimeTrackingEvent(body: tBody, trackEntityId: 1);
 
     blocTest(
       'pastikan emit [LoadingTrackingState, SuccessCreateTimeTrackingState] ketika terima event '

--- a/test/feature/presentation/bloc/tracking/tracking_event_test.dart
+++ b/test/feature/presentation/bloc/tracking/tracking_event_test.dart
@@ -14,7 +14,7 @@ void main() {
         fixture('create_track_body.json'),
       ),
     );
-    final tEvent = CreateTimeTrackingEvent(body: tBody);
+    final tEvent = CreateTimeTrackingEvent(body: tBody, trackEntityId: 0);
 
     test(
       'pastikan output dari fungsi toString',
@@ -22,7 +22,7 @@ void main() {
         // assert
         expect(
           tEvent.toString(),
-          'CreateTimeTrackingEvent{body: ${tEvent.body}}',
+          'CreateTimeTrackingEvent{body: ${tEvent.body}, trackEntityId: ${tEvent.trackEntityId}}',
         );
       },
     );

--- a/test/feature/presentation/bloc/tracking/tracking_state_test.dart
+++ b/test/feature/presentation/bloc/tracking/tracking_state_test.dart
@@ -18,7 +18,10 @@ void main() {
   });
 
   group('SuccessCreateTimeTrackingState', () {
-    final tState = SuccessCreateTimeTrackingState(files: ['1', '2']);
+    final tState = SuccessCreateTimeTrackingState(
+      files: ['1', '2'],
+      trackEntityId: 1,
+    );
 
     test(
       'pastikan output dari fungsi toString',
@@ -26,7 +29,7 @@ void main() {
         // assert
         expect(
           tState.toString(),
-          'SuccessCreateTimeTrackingState{files: ${tState.files}}',
+          'SuccessCreateTimeTrackingState{files: ${tState.files}, trackEntityId: ${tState.trackEntityId}}',
         );
       },
     );


### PR DESCRIPTION
Penyebabnya adalah karena flow yang lama akan menyimpan data track-nya ke lokal jika menerima respon gagal dari endpoint. Nah, celahnya itu di sini. Ternyata respon gagal server-nya itu bisa lama yang mengakibatkan state failure-nya bisa tertimpa sama state yang lain. 

Jadi, solusinya adalah ketika kirim ke server, itu datanya disimpan dulu ke lokal dan jika respon-nya sukses dari server barulah data lokal tadi dihapus.