### PR TITLE
Bugfix - Perbaikan animasi sync yang tidak mengulang di halaman sync page

### DIFF
--- a/lib/feature/presentation/page/sync/sync_page.dart
+++ b/lib/feature/presentation/page/sync/sync_page.dart
@@ -153,7 +153,7 @@ class _SyncPageState extends State<SyncPage> {
         return AlertDialog(
           title: LottieBuilder.asset(
             BaseAnimation.animationUpload,
-            repeat: false,
+            repeat: true,
             width: 92,
             height: 92,
           ),


### PR DESCRIPTION
Penyebabnya adalah karena property `repeat` bernilai `false`. Solusinya tinggal ubah saja menjadi `true`.

https://github.com/CoderJava/dipantau-desktop/assets/17062085/41cb70d2-7637-4e74-b021-9fe75346180d

